### PR TITLE
Update Chapter 4 End-of-chapter quiz

### DIFF
--- a/chapters/en/chapter4/6.mdx
+++ b/chapters/en/chapter4/6.mdx
@@ -25,7 +25,7 @@ Let's test what you learned in this chapter!
 		},
 		{
 			text: "There are no limits.",
-			explain: "Right! There are no limits when uploading models to the Hub.",
+			explain: "There are no limits when uploading models to the Hub.",
             correct: true
 		},
         {
@@ -41,15 +41,15 @@ Let's test what you learned in this chapter!
 	choices={[
 		{
 			text: "Through a GCP account.",
-			explain: "Incorrect!"
+			explain: "While this can work for sending directly, the HuggingFace Hub uses git and git-lfs."
 		},
 		{
 			text: "Through peer-to-peer distribution.",
-			explain: "Incorrect!"
+			explain: "While this can work for sending directly, the HuggingFace Hub uses git and git-lfs."
 		},
 		{
 			text: "Through git and git-lfs.",
-			explain: "Correct! Models on the Hub are simple Git repositories, leveraging <code>git-lfs</code> for large files.",
+			explain: "Models on the Hub are simple Git repositories, leveraging <code>git-lfs</code> for large files.",
             correct: true
 		}
 	]}
@@ -65,22 +65,22 @@ Let's test what you learned in this chapter!
 		},
 		{
 			text: "Create a new model repository.",
-			explain: "Correct! That's not all you can do, though.",
+			explain: "That's not all you can do, though.",
             correct: true
 		},
 		{
 			text: "Manage and edit files.",
-			explain: "Correct! That's not the only right answer, though.",
+			explain: "That's not the only right answer, though.",
             correct: true
 		},
         {
 			text: "Upload files.",
-			explain: "Right! But that's not all.",
+			explain: "But that's not all.",
             correct: true
 		},
         {
 			text: "See diffs across versions.",
-			explain: "Correct! That's not all you can do, though.",
+			explain: "That's not all you can do, though.",
             correct: true
 		}
 	]}
@@ -91,12 +91,12 @@ Let's test what you learned in this chapter!
 <Question
 	choices={[
 		{
-			text: "A rough description of the model, therefore less important than the model and tokenizer files.",
+			text: "A rough description of the model, therefore less important for sharing than the model and tokenizer files.",
 			explain: "It is indeed a description of the model, but it's an important piece: if it's incomplete or absent the model's utility is drastically reduced."
 		},
 		{
 			text: "A way to ensure reproducibility, reusability, and fairness.",
-			explain: "Correct! Sharing the right information in the model card will help users leverage your model and be aware of its limits and biases. ",
+			explain: "Sharing the right information in the model card will help users leverage your model and be aware of its limits and biases. ",
             correct: true
 		},
 		{
@@ -113,22 +113,22 @@ Let's test what you learned in this chapter!
 	choices={[
 		{
 			text: "A tokenizer",
-			explain: "Correct! All tokenizers have the <code>push_to_hub</code> method, and using it will push all the tokenizer files (vocabulary, architecture of the tokenizer, etc.) to a given repo. That's not the only right answer, though!",
+			explain: "All tokenizers have the <code>push_to_hub</code> method, and using it will push all the tokenizer files (vocabulary, architecture of the tokenizer, etc.) to a given repo. That's not the only right answer, though!",
             correct: true
 		},
 		{
 			text: "A model configuration",
-			explain: "Right! All model configurations have the <code>push_to_hub</code> method, and using it will push them to a given repo. What else can you share?",
+			explain: "All model configurations have the <code>push_to_hub</code> method, and using it will push them to a given repo. What else can you share?",
             correct: true
 		},
 		{
 			text: "A model",
-			explain: "Correct! All models have the <code>push_to_hub</code> method, and using it will push them and their configuration files to a given repo. That's not all you can share, though.",
+			explain: "All models have the <code>push_to_hub</code> method, and using it will push them and their configuration files to a given repo. That's not all you can share, though.",
             correct: true
 		},
         {
 			text: "A Trainer",
-			explain: "That's right — the <code>Trainer</code> also implements the <code>push_to_hub</code> method, and using it will upload the model, its configuration, the tokenizer, and a model card draft to a given repo. Try another answer!",
+			explain: "The <code>Trainer</code> also implements the <code>push_to_hub</code> method, and using it will upload the model, its configuration, the tokenizer, and a model card draft to a given repo. Try another answer!",
             correct: true
 		}
 	]}
@@ -138,22 +138,22 @@ Let's test what you learned in this chapter!
 	choices={[
 		{
 			text: "A tokenizer",
-			explain: "Correct! All tokenizers have the <code>push_to_hub</code> method, and using it will push all the tokenizer files (vocabulary, architecture of the tokenizer, etc.) to a given repo. That's not the only right answer, though!",
+			explain: "All tokenizers have the <code>push_to_hub</code> method, and using it will push all the tokenizer files (vocabulary, architecture of the tokenizer, etc.) to a given repo. That's not the only right answer, though!",
             correct: true
 		},
 		{
 			text: "A model configuration",
-			explain: "Right! All model configurations have the <code>push_to_hub</code> method, and using it will push them to a given repo. What else can you share?",
+			explain: "All model configurations have the <code>push_to_hub</code> method, and using it will push them to a given repo. What else can you share?",
             correct: true
 		},
 		{
 			text: "A model",
-			explain: "Correct! All models have the <code>push_to_hub</code> method, and using it will push them and their configuration files to a given repo. That's not all you can share, though.",
+			explain: "All models have the <code>push_to_hub</code> method, and using it will push them and their configuration files to a given repo. That's not all you can share, though.",
             correct: true
 		},
 		{
 			text: "All of the above with a dedicated callback",
-			explain: "That's right — the <code>PushToHubCallback</code> will regularly send all of those objects to a repo during training.",
+			explain: "The <code>PushToHubCallback</code> will regularly send all of those objects to a repo during training.",
             correct: true
 		}
 	]}
@@ -170,12 +170,12 @@ Let's test what you learned in this chapter!
 		},
 		{
 			text: "Run 'huggingface-cli login' in a terminal.",
-			explain: "Correct — this will download and cache your personal token.",
+			explain: "This will download and cache your personal token.",
             correct: true
 		},
 		{
 			text: "Run 'notebook_login()' in a notebook.",
-			explain: "Correct — this will display a widget to let you authenticate.",
+			explain: "This will display a widget to let you authenticate.",
             correct: true
 		},
 	]}
@@ -186,8 +186,8 @@ Let's test what you learned in this chapter!
 <Question
 	choices={[
 		{
-			text: "By calling the push_to_hub method directly on the model and the tokenizer.",
-			explain: "Correct!",
+			text: "By calling the `push_to_hub` method directly on the model and the tokenizer.",
+			explain: "The `push_to_hub` method can be included whent the model or tokenizer is initialized.",
             correct: true
 		},
 		{
@@ -207,7 +207,7 @@ Let's test what you learned in this chapter!
 	choices={[
 		{
 			text: "A commit.",
-			explain: "Correct, the <code>git_commit()</code> method is there for that.",
+			explain: "The <code>git_commit()</code> method is there for that.",
             correct: true
 		},
 		{


### PR DESCRIPTION
## Description
- - -
This pull request fixes several typos in the Chapter 4 End-of-chapter quiz without altering the structure or logic in the page.

## Changes
- - -
* Remove repeated affirmations from explanations
* Added some explanations
* Clarifies some questions
* Added some code marks 

## Purpose
- - -
Because the explanations automatically appear with "Correct!" or "Incorrect." before the explanation, explanations that begin with affirmations such as "Correct", "That's right", and "Right", have been removed to reduce repetition. This pull request adds some explanations when the previous explanation only said whether the answer was correct. Some questions have been slightly modified for clarification. Some code marks, the \` that marks code, have been added.